### PR TITLE
Remove build/bundle.js from `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ $(JS_SENTINAL): package.json
 runserver: $(JS_SENTINAL)
 	npm run start
 
-build: $(JS_SENTINAL) build/bundle.js
+build: $(JS_SENTINAL)
 	npm run build
 
 dev: $(JS_SENTINAL)


### PR DESCRIPTION
React no longer generates a bundle at build/bundle.js - the name is now
randomized.