### PR TITLE
Downgrade chalk to 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -357,7 +357,6 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.11.tgz",
           "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
           "requires": {
-            "chalk": "2.1.0",
             "source-map": "0.5.7",
             "supports-color": "4.4.0"
           }
@@ -387,6 +386,7 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
+        "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -433,7 +433,6 @@
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz",
           "integrity": "sha512-/xr1ADm5bnTjjN+xwoXb7lF4v2rnxMzNZzFU7h8SxB+qB6+IqSTOOqVcpaPTUC2Non/MbQxS3OIZnJpQ2X21aQ==",
           "requires": {
-            "chalk": "2.1.0",
             "esutils": "2.0.2",
             "js-tokens": "3.0.2"
           }
@@ -1375,6 +1374,7 @@
       "requires": {
         "ansi-align": "1.1.0",
         "camelcase": "2.1.1",
+        "chalk": "1.1.3",
         "cli-boxes": "1.0.0",
         "filled-array": "1.1.0",
         "object-assign": "4.1.1",
@@ -1662,13 +1662,27 @@
       }
     },
     "chalk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "3.2.0",
+        "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.4.0"
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "chokidar": {
@@ -1708,7 +1722,10 @@
     "clap": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
-      "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc="
+      "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
+      "requires": {
+        "chalk": "1.1.3"
+      }
     },
     "clean-css": {
       "version": "4.1.7",
@@ -2265,6 +2282,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -2835,7 +2853,6 @@
       "requires": {
         "ajv": "5.2.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.0.1",
@@ -3250,7 +3267,6 @@
           "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.1.0.tgz",
           "integrity": "sha512-mGJinKrAB6hj1cpO1FOuDCfgILozGvYi4Zpk8GrxmNgdd9/9llIA2Xzu5879Fa4ayh7lb9ej2NdvuNLMCjbrMg==",
           "requires": {
-            "chalk": "2.1.0",
             "diff": "3.3.0",
             "jest-get-type": "21.0.2",
             "pretty-format": "21.1.0"
@@ -3261,7 +3277,6 @@
           "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.1.0.tgz",
           "integrity": "sha512-V/Xindf+VY5UM+oz9Nhsv0Ql93lRcKS7tHtVoXtlXkZXoXpydHwuezkLLCpZkH/Uew5y2OyDZpnlxPvEalJZng==",
           "requires": {
-            "chalk": "2.1.0",
             "jest-get-type": "21.0.2",
             "pretty-format": "21.1.0"
           }
@@ -3271,7 +3286,6 @@
           "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.1.0.tgz",
           "integrity": "sha512-BwKrjR4HvGoodYw3PFh95IU4qDk3nVOf3LqOKRaaR6486bJM8IZIlxWR8yfxhAN7nDGBDco/TR+U50WcPgzvgA==",
           "requires": {
-            "chalk": "2.1.0",
             "micromatch": "2.3.11",
             "slash": "1.0.0"
           }
@@ -4704,7 +4718,6 @@
           "integrity": "sha512-ISnDjHv9m0nCrSKFC+Cnr9SotaWHYRP+TK81vMtPwkV+/70JbfYJT6ZnuqgqyAnTYE4f/aCe6uyMPKHAVT1RpA==",
           "requires": {
             "ansi-escapes": "3.0.0",
-            "chalk": "2.1.0",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
             "is-ci": "1.0.10",
@@ -4739,7 +4752,6 @@
           "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.1.0.tgz",
           "integrity": "sha512-RQnWwHRSIRvtyJQeZTpXUmsNYVVr/qu3XWfV3FTFkDsxHQi6Sj5sfUK5FHCNUCXIuFTs+r3qbYoMz2q8rdm/EA==",
           "requires": {
-            "chalk": "2.1.0",
             "glob": "7.1.2",
             "jest-environment-jsdom": "21.1.0",
             "jest-environment-node": "21.1.0",
@@ -4757,7 +4769,6 @@
           "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.1.0.tgz",
           "integrity": "sha512-mGJinKrAB6hj1cpO1FOuDCfgILozGvYi4Zpk8GrxmNgdd9/9llIA2Xzu5879Fa4ayh7lb9ej2NdvuNLMCjbrMg==",
           "requires": {
-            "chalk": "2.1.0",
             "diff": "3.3.0",
             "jest-get-type": "21.0.2",
             "pretty-format": "21.1.0"
@@ -4805,7 +4816,6 @@
           "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.1.0.tgz",
           "integrity": "sha512-YjbAaXN6K5f8rtwPVxkMRIYNZGB5GiJcApcj/5ER7uGJrqJMqyCklMAPZR5Gq8XPzzuDVfoB2h7kxyOGVqaxrw==",
           "requires": {
-            "chalk": "2.1.0",
             "expect": "21.1.0",
             "graceful-fs": "4.1.11",
             "jest-diff": "21.1.0",
@@ -4820,7 +4830,6 @@
           "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.1.0.tgz",
           "integrity": "sha512-V/Xindf+VY5UM+oz9Nhsv0Ql93lRcKS7tHtVoXtlXkZXoXpydHwuezkLLCpZkH/Uew5y2OyDZpnlxPvEalJZng==",
           "requires": {
-            "chalk": "2.1.0",
             "jest-get-type": "21.0.2",
             "pretty-format": "21.1.0"
           }
@@ -4830,7 +4839,6 @@
           "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.1.0.tgz",
           "integrity": "sha512-BwKrjR4HvGoodYw3PFh95IU4qDk3nVOf3LqOKRaaR6486bJM8IZIlxWR8yfxhAN7nDGBDco/TR+U50WcPgzvgA==",
           "requires": {
-            "chalk": "2.1.0",
             "micromatch": "2.3.11",
             "slash": "1.0.0"
           }
@@ -4851,7 +4859,6 @@
           "integrity": "sha512-HKh0pnf2SwR3hDaToONjHrR9ds282QFkxCA9xMet3JpsdLL24oRYMLSQ7jtepZfA6EP+XycRE6RfcMBD8emetg==",
           "requires": {
             "browser-resolve": "1.11.2",
-            "chalk": "2.1.0",
             "is-builtin-module": "1.0.0"
           }
         },
@@ -4871,7 +4878,6 @@
             "babel-core": "6.26.0",
             "babel-jest": "21.0.2",
             "babel-plugin-istanbul": "4.1.4",
-            "chalk": "2.1.0",
             "convert-source-map": "1.5.0",
             "graceful-fs": "4.1.11",
             "jest-config": "21.1.0",
@@ -4892,7 +4898,6 @@
           "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.1.0.tgz",
           "integrity": "sha512-oYASKqxO/Ghbdd96z/3KSQ1y4YUtqrQVzSKbnz3yjGsi1nu3AXMPmjRCM/CZXL+H+DAIgMirj5Uq0dZOxo6Bnw==",
           "requires": {
-            "chalk": "2.1.0",
             "jest-diff": "21.1.0",
             "jest-matcher-utils": "21.1.0",
             "mkdirp": "0.5.1",
@@ -4906,7 +4911,6 @@
           "integrity": "sha512-PJxaShBieLpB55NV4+loIZHiOlfZHjAGzVRp9BDzrr2m70UxQViDJenNdz4edJMWXJLjp817t1QrWi+LjcRaKw==",
           "requires": {
             "callsites": "2.0.0",
-            "chalk": "2.1.0",
             "graceful-fs": "4.1.11",
             "jest-message-util": "21.1.0",
             "jest-mock": "21.1.0",
@@ -4919,7 +4923,6 @@
           "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.1.0.tgz",
           "integrity": "sha512-xS0cyErNWpsLFlGkn/b87pk/Mv7J+mCTs8hQ4KmtOIIoM1sHYobXII8AtkoN8FC7E3+Ptxjo+/3xWk6LK1dKcw==",
           "requires": {
-            "chalk": "2.1.0",
             "jest-get-type": "21.0.2",
             "leven": "2.1.0",
             "pretty-format": "21.1.0"
@@ -5164,7 +5167,6 @@
           "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.1.0.tgz",
           "integrity": "sha512-RQnWwHRSIRvtyJQeZTpXUmsNYVVr/qu3XWfV3FTFkDsxHQi6Sj5sfUK5FHCNUCXIuFTs+r3qbYoMz2q8rdm/EA==",
           "requires": {
-            "chalk": "2.1.0",
             "glob": "7.1.2",
             "jest-environment-jsdom": "21.1.0",
             "jest-environment-node": "21.1.0",
@@ -5182,7 +5184,6 @@
           "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.1.0.tgz",
           "integrity": "sha512-mGJinKrAB6hj1cpO1FOuDCfgILozGvYi4Zpk8GrxmNgdd9/9llIA2Xzu5879Fa4ayh7lb9ej2NdvuNLMCjbrMg==",
           "requires": {
-            "chalk": "2.1.0",
             "diff": "3.3.0",
             "jest-get-type": "21.0.2",
             "pretty-format": "21.1.0"
@@ -5230,7 +5231,6 @@
           "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.1.0.tgz",
           "integrity": "sha512-YjbAaXN6K5f8rtwPVxkMRIYNZGB5GiJcApcj/5ER7uGJrqJMqyCklMAPZR5Gq8XPzzuDVfoB2h7kxyOGVqaxrw==",
           "requires": {
-            "chalk": "2.1.0",
             "expect": "21.1.0",
             "graceful-fs": "4.1.11",
             "jest-diff": "21.1.0",
@@ -5245,7 +5245,6 @@
           "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.1.0.tgz",
           "integrity": "sha512-V/Xindf+VY5UM+oz9Nhsv0Ql93lRcKS7tHtVoXtlXkZXoXpydHwuezkLLCpZkH/Uew5y2OyDZpnlxPvEalJZng==",
           "requires": {
-            "chalk": "2.1.0",
             "jest-get-type": "21.0.2",
             "pretty-format": "21.1.0"
           }
@@ -5255,7 +5254,6 @@
           "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.1.0.tgz",
           "integrity": "sha512-BwKrjR4HvGoodYw3PFh95IU4qDk3nVOf3LqOKRaaR6486bJM8IZIlxWR8yfxhAN7nDGBDco/TR+U50WcPgzvgA==",
           "requires": {
-            "chalk": "2.1.0",
             "micromatch": "2.3.11",
             "slash": "1.0.0"
           }
@@ -5276,7 +5274,6 @@
           "integrity": "sha512-HKh0pnf2SwR3hDaToONjHrR9ds282QFkxCA9xMet3JpsdLL24oRYMLSQ7jtepZfA6EP+XycRE6RfcMBD8emetg==",
           "requires": {
             "browser-resolve": "1.11.2",
-            "chalk": "2.1.0",
             "is-builtin-module": "1.0.0"
           }
         },
@@ -5288,7 +5285,6 @@
             "babel-core": "6.26.0",
             "babel-jest": "21.0.2",
             "babel-plugin-istanbul": "4.1.4",
-            "chalk": "2.1.0",
             "convert-source-map": "1.5.0",
             "graceful-fs": "4.1.11",
             "jest-config": "21.1.0",
@@ -5309,7 +5305,6 @@
           "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.1.0.tgz",
           "integrity": "sha512-oYASKqxO/Ghbdd96z/3KSQ1y4YUtqrQVzSKbnz3yjGsi1nu3AXMPmjRCM/CZXL+H+DAIgMirj5Uq0dZOxo6Bnw==",
           "requires": {
-            "chalk": "2.1.0",
             "jest-diff": "21.1.0",
             "jest-matcher-utils": "21.1.0",
             "mkdirp": "0.5.1",
@@ -5323,7 +5318,6 @@
           "integrity": "sha512-PJxaShBieLpB55NV4+loIZHiOlfZHjAGzVRp9BDzrr2m70UxQViDJenNdz4edJMWXJLjp817t1QrWi+LjcRaKw==",
           "requires": {
             "callsites": "2.0.0",
-            "chalk": "2.1.0",
             "graceful-fs": "4.1.11",
             "jest-message-util": "21.1.0",
             "jest-mock": "21.1.0",
@@ -5336,7 +5330,6 @@
           "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.1.0.tgz",
           "integrity": "sha512-xS0cyErNWpsLFlGkn/b87pk/Mv7J+mCTs8hQ4KmtOIIoM1sHYobXII8AtkoN8FC7E3+Ptxjo+/3xWk6LK1dKcw==",
           "requires": {
-            "chalk": "2.1.0",
             "jest-get-type": "21.0.2",
             "leven": "2.1.0",
             "pretty-format": "21.1.0"
@@ -6656,6 +6649,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -6691,6 +6685,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -6725,6 +6720,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -6758,6 +6754,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -6791,6 +6788,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -6824,6 +6822,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -6857,6 +6856,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -6891,6 +6891,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -6925,6 +6926,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7008,6 +7010,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7041,6 +7044,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7087,6 +7091,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7127,6 +7132,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7161,6 +7167,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7197,6 +7204,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7233,6 +7241,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7301,6 +7310,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7337,6 +7347,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7371,6 +7382,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7405,6 +7417,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7438,6 +7451,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7473,6 +7487,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7519,6 +7534,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7554,6 +7570,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7594,6 +7611,7 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
+            "chalk": "1.1.3",
             "js-base64": "2.1.9",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
@@ -7832,6 +7850,7 @@
       "requires": {
         "address": "1.0.2",
         "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
         "cross-spawn": "5.1.0",
         "detect-port-alt": "1.1.3",
         "escape-string-regexp": "1.0.5",
@@ -7859,6 +7878,7 @@
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
           "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
           "requires": {
+            "chalk": "1.1.3",
             "esutils": "2.0.2",
             "js-tokens": "3.0.2"
           }
@@ -7937,6 +7957,7 @@
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
           "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
           "requires": {
+            "chalk": "1.1.3",
             "esutils": "2.0.2",
             "js-tokens": "3.0.2"
           }
@@ -8839,6 +8860,7 @@
       "requires": {
         "ajv": "4.11.8",
         "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
         "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
         "string-width": "2.1.1"
@@ -9094,6 +9116,7 @@
       "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
       "requires": {
         "boxen": "0.6.0",
+        "chalk": "1.1.3",
         "configstore": "2.1.0",
         "is-npm": "1.0.0",
         "latest-version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-preset-react-app": "^3.0.2",
     "babel-runtime": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
-    "chalk": "2.1.0",
+    "chalk": "1.1.3",
     "css-loader": "0.28.7",
     "dotenv": "4.0.0",
     "eslint": "4.7.2",
@@ -62,6 +62,7 @@
   },
   "greenkeeper": {
     "ignore": [
+      "chalk",
       "jsdom"
     ]
   },


### PR DESCRIPTION
This fixes an error I'm getting in dev mode:

```
Uncaught Error: Module build failed: TypeError: chalk.stripColor is not
a function
    at stringLength
    (/home/nnyby/public_html/econplayground.js/node_modules/react-dev-utils/eslintFormatter.js:70:22)
```