### PR TITLE
Remove default test watch mode

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -18,10 +18,4 @@ require('../config/env');
 const jest = require('jest');
 const argv = process.argv.slice(2);
 
-// Watch unless on CI or in coverage mode
-if (!process.env.CI && argv.indexOf('--coverage') < 0) {
-  argv.push('--watch');
-}
-
-
 jest.run(argv);


### PR DESCRIPTION
`make test` should just run the tests, not go into this annoying
interactive mode.