### PR TITLE
Use const instead of let for function names

### DIFF
--- a/src/Graph.js
+++ b/src/Graph.js
@@ -8,7 +8,7 @@ import { defaultGraph } from './GraphMapping';
 import { forceFloat, getOffset } from './utils';
 
 
-let applyDefaults = function(obj, defaults) {
+const applyDefaults = function(obj, defaults) {
     let o = {};
     for (var key in obj) {
         if (typeof obj[key] === 'undefined') {
@@ -349,7 +349,7 @@ class DemandSupplyGraph extends Graph {
     }
 }
 
-let mkDemandSupply = function(board, options) {
+const mkDemandSupply = function(board, options) {
     let g = new DemandSupplyGraph(board, options);
     g.make();
     g.postMake();
@@ -485,7 +485,7 @@ class NonLinearDemandSupplyGraph extends Graph {
     }
 }
 
-let mkNonLinearDemandSupply = function(board, options) {
+const mkNonLinearDemandSupply = function(board, options) {
     let g = new NonLinearDemandSupplyGraph(board, options);
     g.make();
     g.postMake();
@@ -557,7 +557,7 @@ class CobbDouglasGraph extends Graph {
     }
 }
 
-let mkCobbDouglas = function(board, options) {
+const mkCobbDouglas = function(board, options) {
     let g = new CobbDouglasGraph(board, options);
     g.make();
     g.postMake();
@@ -585,7 +585,7 @@ class ConsumptionLeisureGraph extends Graph {
     }
 }
 
-let mkConsumptionLeisure = function(board, options) {
+const mkConsumptionLeisure = function(board, options) {
     let g = new ConsumptionLeisureGraph(board, options);
     g.make();
     g.postMake();

--- a/src/GraphMapping.js
+++ b/src/GraphMapping.js
@@ -9,7 +9,7 @@ import { forceFloat } from './utils';
 /**
  * Returns the current graph settings as a persistable JSON object.
  */
-let exportGraph = function(state) {
+const exportGraph = function(state) {
     let obj = {
         title: state.gTitle,
         description: state.gDescription,
@@ -102,7 +102,7 @@ let exportGraph = function(state) {
 /**
  * Import the json graph into the current state.
  */
-let importGraph = function(json, obj) {
+const importGraph = function(json, obj) {
     const updateObj = {
         gId: json.id,
         gTitle: json.title,

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ import Cookies from 'js-cookie';
 /**
  * A wrapper for `fetch` that passes along auth credentials.
  */
-let authedFetch = function(url, method = 'get', data = null) {
+const authedFetch = function(url, method = 'get', data = null) {
     const token = Cookies.get('csrftoken');
     return fetch(url, {
         method: method,
@@ -22,7 +22,7 @@ let authedFetch = function(url, method = 'get', data = null) {
  * Returns a Promise containing the submission for the current user
  * and given graph id, if it exists.
  */
-let getSubmission = function(graphId) {
+const getSubmission = function(graphId) {
     return authedFetch(`/api/submissions/${graphId}/`)
         .then(function(response) {
             if (response.status === 200) {
@@ -33,7 +33,7 @@ let getSubmission = function(graphId) {
         });
 };
 
-let createSubmission = function(data) {
+const createSubmission = function(data) {
     return authedFetch('/api/submissions/', 'post', JSON.stringify(data))
         .then(function(response) {
             if (response.status === 201) {
@@ -45,7 +45,7 @@ let createSubmission = function(data) {
         });
 };
 
-let getOrCreateSubmission = function(data) {
+const getOrCreateSubmission = function(data) {
     return authedFetch(`/api/submissions/${data.graph}/`)
         .then(function(response) {
             if (response.status === 200) {
@@ -56,7 +56,7 @@ let getOrCreateSubmission = function(data) {
         });
 };
 
-let getL1SubmissionOffset = function(submission) {
+const getL1SubmissionOffset = function(submission) {
     if (!submission) {
         return 0;
     }
@@ -69,7 +69,7 @@ let getL1SubmissionOffset = function(submission) {
     return 0;
 };
 
-let getL2SubmissionOffset = function(submission) {
+const getL2SubmissionOffset = function(submission) {
     if (!submission) {
         return 0;
     }
@@ -85,7 +85,7 @@ let getL2SubmissionOffset = function(submission) {
 /**
  * Propagate a form update to a callback.
  */
-let handleFormUpdate = function(e) {
+const handleFormUpdate = function(e) {
     let obj = {};
 
     // Use the element's id as the attribute name, and fall
@@ -121,7 +121,7 @@ let handleFormUpdate = function(e) {
  * Given a line's slope and y-intercept, return its
  * y-offset at x-value n.
  */
-let getOffset = function(slope, y, n) {
+const getOffset = function(slope, y, n) {
     const xpos = (slope * n) + y;
     return xpos - n;
 };
@@ -130,7 +130,7 @@ let getOffset = function(slope, y, n) {
  * Force a value into a float that will be acceptable to the Django
  * API's DecimalFields. This is currently capped to 2 decimal places.
  */
-let forceFloat = function(n) {
+const forceFloat = function(n) {
     n = Number(n)
     if (isNaN(n) || typeof n === 'undefined') {
         n = 0;
@@ -138,7 +138,7 @@ let forceFloat = function(n) {
     return Math.round(n * 100) / 100;
 };
 
-let displayGraphType = function(gType) {
+const displayGraphType = function(gType) {
     let name = '';
     switch (gType) {
         case 0:


### PR DESCRIPTION
Functions don't change value, so const should be fine. I'm still unclear
whether this method, or using traditional function syntax like:

```
function abc() {
}
```

is considered best practice in the es6/react world. My current
understanding is that, both ways are fine and that it doesn't really
matter.