### PR TITLE
remove isRequired from GraphEditor.gId

### DIFF
--- a/src/GraphEditor.js
+++ b/src/GraphEditor.js
@@ -544,7 +544,7 @@ export default class GraphEditor extends React.Component {
 }
 
 GraphEditor.propTypes = {
-    gId: PropTypes.number.idRequired,
+    gId: PropTypes.number,
     gTitle: PropTypes.string,
     gDescription: PropTypes.string,
 


### PR DESCRIPTION
The graph's ID isn't always passed in to the GraphEditor, if, for example, we're creating a new graph, via Editor.js.