### PR TITLE
PMT #115699: Update layout of edit page

### DIFF
--- a/src/GraphEditor.js
+++ b/src/GraphEditor.js
@@ -9,17 +9,17 @@ import DemandSupplyEditor from './editors/DemandSupplyEditor';
 import CommonGraphEditor from './editors/CommonGraphEditor';
 import CommonGraphSettings from './editors/CommonGraphSettings';
 import JXGBoard from './JXGBoard';
-import {displayGraphType} from './utils';
+import {displayGraphType, handleFormUpdate} from './utils';
 
 export default class GraphEditor extends React.Component {
     title() {
         return (
             <div>
-            <h1>{displayGraphType(this.props.gType)}</h1>
-            <p className="lead text-secondary">
-                Add and modify the information of your graph.
-            </p>
-        </div>
+                <h1>{displayGraphType(this.props.gType)}</h1>
+                <p className="lead text-secondary">
+                    Add and modify the information of your graph.
+                </p>
+            </div>
         );
     }
     render() {
@@ -34,6 +34,19 @@ export default class GraphEditor extends React.Component {
                     <form>
                         <div className="row">
                             <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                                <h2>Scenario</h2>
+                                <div className="form-group">
+                                    <label htmlFor="gTitle">
+                                        Title
+                                    </label>
+                                    <input id="gTitle"
+                                        onChange={handleFormUpdate.bind(this)}
+                                        value={this.props.gTitle}
+                                        className="form-control form-control-sm"
+                                        type="text"
+                                        maxLength="140"
+                                    />
+                                </div>
                                 <JXGBoard
                                     id={'editing-graph'}
                                     width={540}
@@ -67,13 +80,7 @@ export default class GraphEditor extends React.Component {
                                     gInstructorNotes={this.props.gInstructorNotes}
                                     gDescription={this.props.gDescription}
                                     updateGraph={this.props.updateGraph}
-                                    />
-                                {this.props.gId &&
-                                    <div className="form-group">
-                                            <a href={"/graph/" + this.props.gId + "/public/"}
-                                                   className="btn btn-secondary">Student View</a>
-                                        </div>
-                                }
+                                />
                             </div>
                             <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                                 <CommonGraphSettings
@@ -104,19 +111,32 @@ export default class GraphEditor extends React.Component {
                                     gIntersectionVertLineLabel={this.props.gIntersectionVertLineLabel}
                                     updateGraph={this.props.updateGraph}
                                 />
-
+                            </div>
                         </div>
-                    </div>
-                    <hr/>
-                    <button type="button"
-                        className="btn btn-primary btn-sm"
-                        onClick={this.handleSaveGraph.bind(this)}>Save</button>
-                    {this.props.gId &&
-                            <a role="button"
-                                className="btn btn-danger btn-sm float-md-right"
-                                href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>}
-                        </form>
-                    </div>
+                        <hr/>
+                        <div className="row">
+                            <div className="ml-3  mr-2">
+                                <button type="button"
+                                    className="btn btn-primary"
+                                    onClick={this.handleSaveGraph.bind(this)}>Save</button>
+                            </div>
+                            {this.props.gId &&
+                                    <div>
+                                        <button onClick={this.handleSaveGraph.bind(this)}
+                                            href={"/graph/" + this.props.gId + "/public/"}
+                                            className="btn btn-secondary">Save and View</button>
+                                    </div>
+                            }
+                            {this.props.gId &&
+                                    <div className="ml-auto mr-3">
+                                        <a role="button"
+                                            className="btn btn-danger float-md-right"
+                                            href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>
+                                    </div>
+                            }
+                        </div>
+                    </form>
+                </div>
             );
         } else if (this.props.gType === 1) {
             // Non-Linear Demand Supply
@@ -125,6 +145,19 @@ export default class GraphEditor extends React.Component {
                 <form>
                     <div className="row">
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                            <h2>Scenario</h2>
+                            <div className="form-group">
+                                <label htmlFor="gTitle">
+                                    Title
+                                </label>
+                                <input id="gTitle"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    value={this.props.gTitle}
+                                    className="form-control form-control-sm"
+                                    type="text"
+                                    maxLength="140"
+                                />
+                            </div>
                             <JXGBoard
                                 id={'editing-graph'}
                                 width={540}
@@ -161,12 +194,6 @@ export default class GraphEditor extends React.Component {
                                 gInstructorNotes={this.props.gInstructorNotes}
                                 gDescription={this.props.gDescription}
                                 updateGraph={this.props.updateGraph} />
-                                {this.props.gId &&
-                                    <div className="form-group">
-                                            <a href={"/graph/" + this.props.gId + "/public/"}
-                                                   className="btn btn-secondary">Student View</a>
-                                        </div>
-                                }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <CommonGraphSettings
@@ -196,19 +223,32 @@ export default class GraphEditor extends React.Component {
                                 gIntersectionVertLineLabel={this.props.gIntersectionVertLineLabel}
                                 updateGraph={this.props.updateGraph}
                             />
-
+                        </div>
                     </div>
-                </div>
-                <hr/>
-                <button type="button"
-                    className="btn btn-primary btn-sm"
-                    onClick={this.handleSaveGraph.bind(this)}>Save</button>
-                {this.props.gId &&
-                        <a role="button"
-                            className="btn btn-danger btn-sm float-md-right"
-                            href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>}
-                    </form>
-                </div>;
+                    <hr/>
+                    <div className="row">
+                        <div className="ml-3  mr-2">
+                            <button type="button"
+                                className="btn btn-primary"
+                                onClick={this.handleSaveGraph.bind(this)}>Save</button>
+                        </div>
+                        {this.props.gId &&
+                                <div>
+                                    <button onClick={this.handleSaveGraph.bind(this)}
+                                        href={"/graph/" + this.props.gId + "/public/"}
+                                        className="btn btn-secondary">Save and View</button>
+                                </div>
+                        }
+                        {this.props.gId &&
+                                <div className="ml-auto mr-3">
+                                    <a role="button"
+                                        className="btn btn-danger float-md-right"
+                                        href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>
+                                </div>
+                        }
+                    </div>
+                </form>
+            </div>;
         } else if (this.props.gType === 3) {
             // Cobb-Douglas
             return <div className="GraphEditor">
@@ -216,6 +256,19 @@ export default class GraphEditor extends React.Component {
                 <form>
                     <div className="row">
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                            <h2>Scenario</h2>
+                            <div className="form-group">
+                                <label htmlFor="gTitle">
+                                    Title
+                                </label>
+                                <input id="gTitle"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    value={this.props.gTitle}
+                                    className="form-control form-control-sm"
+                                    type="text"
+                                    maxLength="140"
+                                />
+                            </div>
                             <JXGBoard
                                 id={'editing-graph'}
                                 width={540}
@@ -249,12 +302,6 @@ export default class GraphEditor extends React.Component {
                                 gInstructorNotes={this.props.gInstructorNotes}
                                 gDescription={this.props.gDescription}
                                 updateGraph={this.props.updateGraph} />
-                                {this.props.gId &&
-                                     <div className="form-group">
-                                            <a href={"/graph/" + this.props.gId + "/public/"}
-                                                   className="btn btn-secondary">Student View</a>
-                                        </div>
-                                }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <CommonGraphSettings
@@ -282,19 +329,32 @@ export default class GraphEditor extends React.Component {
                                 isInstructor={true}
                                 updateGraph={this.props.updateGraph}
                             />
-
+                        </div>
                     </div>
+                </form>
+                <hr/>
+                <div className="row">
+                    <div className="ml-3  mr-2">
+                        <button type="button"
+                            className="btn btn-primary"
+                            onClick={this.handleSaveGraph.bind(this)}>Save</button>
+                    </div>
+                    {this.props.gId &&
+                            <div>
+                                <button onClick={this.handleSaveGraph.bind(this)}
+                                    href={"/graph/" + this.props.gId + "/public/"}
+                                    className="btn btn-secondary">Save and View</button>
+                            </div>
+                    }
+                    {this.props.gId &&
+                            <div className="ml-auto mr-3">
+                                <a role="button"
+                                    className="btn btn-danger float-md-right"
+                                    href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>
+                            </div>
+                    }
                 </div>
-            </form>
-            <hr/>
-            <button type="button"
-                className="btn btn-primary btn-sm"
-                onClick={this.handleSaveGraph.bind(this)}>Save</button>
-            {this.props.gId &&
-                    <a role="button"
-                        className="btn btn-danger btn-sm float-md-right"
-                        href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>}
-                </div>;
+            </div>;
         } else if (this.props.gType === 5) {
             // Consumption Leisure
             return <div className="GraphEditor">
@@ -302,6 +362,19 @@ export default class GraphEditor extends React.Component {
                 <form>
                     <div className="row">
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                            <h2>Scenario</h2>
+                            <div className="form-group">
+                                <label htmlFor="gTitle">
+                                    Title
+                                </label>
+                                <input id="gTitle"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    value={this.props.gTitle}
+                                    className="form-control form-control-sm"
+                                    type="text"
+                                    maxLength="140"
+                                />
+                            </div>
                             <JXGBoard
                                 id={'editing-graph'}
                                 width={540}
@@ -335,12 +408,6 @@ export default class GraphEditor extends React.Component {
                                 gDisplayShadow={this.props.gDisplayShadow}
                                 gIsPublished={this.props.gIsPublished}
                                 updateGraph={this.props.updateGraph} />
-                                {this.props.gId &&
-                                     <div className="form-group">
-                                            <a href={"/graph/" + this.props.gId + "/public/"}
-                                                   className="btn btn-secondary">Student View</a>
-                                        </div>
-                                }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <ConsumptionLeisureEditor
@@ -363,15 +430,29 @@ export default class GraphEditor extends React.Component {
                     </div>
                 </div>
                 <hr/>
-                <button type="button"
-                    className="btn btn-primary btn-sm"
-                    onClick={this.handleSaveGraph.bind(this)}>Save</button>
-                {this.props.gId &&
-                        <a role="button"
-                            className="btn btn-danger btn-sm float-md-right"
-                            href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>}
-                    </form>
-                </div>;
+                <div className="row">
+                    <div className="ml-3  mr-2">
+                        <button type="button"
+                            className="btn btn-primary"
+                            onClick={this.handleSaveGraph.bind(this)}>Save</button>
+                    </div>
+                    {this.props.gId &&
+                            <div>
+                                <button onClick={this.handleSaveGraph.bind(this)}
+                                    href={"/graph/" + this.props.gId + "/public/"}
+                                    className="btn btn-secondary">Save and View</button>
+                            </div>
+                    }
+                    {this.props.gId &&
+                            <div className="ml-auto mr-3">
+                                <a role="button"
+                                    className="btn btn-danger float-md-right"
+                                    href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>
+                            </div>
+                    }
+                </div>
+            </form>
+        </div>;
         } else if (this.props.gType === 7) {
             // Consumption Savings
             return <div className="GraphEditor">
@@ -379,6 +460,19 @@ export default class GraphEditor extends React.Component {
                 <form>
                     <div className="row">
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                            <h2>Scenario</h2>
+                            <div className="form-group">
+                                <label htmlFor="gTitle">
+                                    Title
+                                </label>
+                                <input id="gTitle"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    value={this.props.gTitle}
+                                    className="form-control form-control-sm"
+                                    type="text"
+                                    maxLength="140"
+                                />
+                            </div>
                             <JXGBoard
                                 id={'editing-graph'}
                                 width={540}
@@ -408,12 +502,6 @@ export default class GraphEditor extends React.Component {
                                 gInstructorNotes={this.props.gInstructorNotes}
                                 gDescription={this.props.gDescription}
                                 updateGraph={this.props.updateGraph} />
-                                {this.props.gId &&
-                                     <div className="form-group">
-                                            <a href={"/graph/" + this.props.gId + "/public/"}
-                                                   className="btn btn-secondary">Student View</a>
-                                        </div>
-                                }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <CommonGraphSettings
@@ -444,15 +532,29 @@ export default class GraphEditor extends React.Component {
                         </div>
                     </div>
                     <hr/>
-                    <button type="button"
-                        className="btn btn-primary btn-sm"
-                        onClick={this.handleSaveGraph.bind(this)}>Save</button>
-                    {this.props.gId &&
-                            <a role="button"
-                                className="btn btn-danger btn-sm float-md-right"
-                                href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>}
-                        </form>
-                    </div>;
+                    <div className="row">
+                        <div className="ml-3  mr-2">
+                            <button type="button"
+                                className="btn btn-primary"
+                                onClick={this.handleSaveGraph.bind(this)}>Save</button>
+                        </div>
+                        {this.props.gId &&
+                                <div>
+                                    <button onClick={this.handleSaveGraph.bind(this)}
+                                        href={"/graph/" + this.props.gId + "/public/"}
+                                        className="btn btn-secondary">Save and View</button>
+                                </div>
+                        }
+                        {this.props.gId &&
+                                <div className="ml-auto mr-3">
+                                    <a role="button"
+                                        className="btn btn-danger float-md-right"
+                                        href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>
+                                </div>
+                        }
+                    </div>
+                </form>
+            </div>;
         } else if (this.props.gType === 8) {
             // Aggregate Demand - Aggregate Supply
             return <div className="GraphEditor">
@@ -460,6 +562,19 @@ export default class GraphEditor extends React.Component {
                 <form>
                     <div className="row">
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                            <h2>Scenario</h2>
+                            <div className="form-group">
+                                <label htmlFor="gTitle">
+                                    Title
+                                </label>
+                                <input id="gTitle"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    value={this.props.gTitle}
+                                    className="form-control form-control-sm"
+                                    type="text"
+                                    maxLength="140"
+                                />
+                            </div>
                             <JXGBoard
                                 id={'editing-graph'}
                                 width={540}
@@ -506,12 +621,6 @@ export default class GraphEditor extends React.Component {
                                 gInstructorNotes={this.props.gInstructorNotes}
                                 gDescription={this.props.gDescription}
                                 updateGraph={this.props.updateGraph} />
-                                {this.props.gId &&
-                                     <div className="form-group">
-                                            <a href={"/graph/" + this.props.gId + "/public/"}
-                                                   className="btn btn-secondary">Student View</a>
-                                        </div>
-                                }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <CommonGraphSettings
@@ -563,15 +672,29 @@ export default class GraphEditor extends React.Component {
                     </div>
                 </div>
                 <hr/>
-                <button type="button"
-                    className="btn btn-primary btn-sm"
-                    onClick={this.handleSaveGraph.bind(this)}>Save</button>
-                {this.props.gId &&
-                        <a role="button"
-                            className="btn btn-danger btn-sm float-md-right"
-                            href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>}
-                    </form>
-                </div>;
+                <div className="row">
+                    <div className="ml-3  mr-2">
+                        <button type="button"
+                            className="btn btn-primary"
+                            onClick={this.handleSaveGraph.bind(this)}>Save</button>
+                    </div>
+                    {this.props.gId &&
+                            <div>
+                                <button onClick={this.handleSaveGraph.bind(this)}
+                                    href={"/graph/" + this.props.gId + "/public/"}
+                                    className="btn btn-secondary">Save and View</button>
+                            </div>
+                    }
+                    {this.props.gId &&
+                            <div className="ml-auto mr-3">
+                                <a role="button"
+                                    className="btn btn-danger float-md-right"
+                                    href={"/graph/" + this.props.gId + "/delete/"}>Delete Graph</a>
+                            </div>
+                    }
+                </div>
+            </form>
+        </div>;
         } else {
             return <div>Unknown graph type: {this.props.gType}</div>;
         }

--- a/src/GraphEditor.js
+++ b/src/GraphEditor.js
@@ -80,7 +80,13 @@ export default class GraphEditor extends React.Component {
                                     gInstructorNotes={this.props.gInstructorNotes}
                                     gDescription={this.props.gDescription}
                                     updateGraph={this.props.updateGraph}
-                                />
+                                    />
+                                {this.props.gId &&
+                                    <div className="form-group">
+                                            <a href={"/graph/" + this.props.gId + "/public/"}
+                                                   className="btn btn-secondary">Student View</a>
+                                        </div>
+                                    }
                             </div>
                             <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                                 <CommonGraphSettings
@@ -186,7 +192,13 @@ export default class GraphEditor extends React.Component {
                                 gTitle={this.props.gTitle}
                                 gInstructorNotes={this.props.gInstructorNotes}
                                 gDescription={this.props.gDescription}
-                                updateGraph={this.props.updateGraph} />
+            updateGraph={this.props.updateGraph} />
+                                {this.props.gId &&
+                                    <div className="form-group">
+                                            <a href={"/graph/" + this.props.gId + "/public/"}
+                                                   className="btn btn-secondary">Student View</a>
+                                        </div>
+                                    }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <CommonGraphSettings
@@ -287,7 +299,13 @@ export default class GraphEditor extends React.Component {
                                 gTitle={this.props.gTitle}
                                 gInstructorNotes={this.props.gInstructorNotes}
                                 gDescription={this.props.gDescription}
-                                updateGraph={this.props.updateGraph} />
+            updateGraph={this.props.updateGraph} />
+                                {this.props.gId &&
+                                    <div className="form-group">
+                                            <a href={"/graph/" + this.props.gId + "/public/"}
+                                                   className="btn btn-secondary">Student View</a>
+                                        </div>
+                                    }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <CommonGraphSettings
@@ -386,7 +404,13 @@ export default class GraphEditor extends React.Component {
                                 gShowIntersection={this.props.gShowIntersection}
                                 gDisplayShadow={this.props.gDisplayShadow}
                                 gIsPublished={this.props.gIsPublished}
-                                updateGraph={this.props.updateGraph} />
+            updateGraph={this.props.updateGraph} />
+                                {this.props.gId &&
+                                    <div className="form-group">
+                                            <a href={"/graph/" + this.props.gId + "/public/"}
+                                                   className="btn btn-secondary">Student View</a>
+                                        </div>
+                                    }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <ConsumptionLeisureEditor
@@ -473,7 +497,13 @@ export default class GraphEditor extends React.Component {
                                 gTitle={this.props.gTitle}
                                 gInstructorNotes={this.props.gInstructorNotes}
                                 gDescription={this.props.gDescription}
-                                updateGraph={this.props.updateGraph} />
+            updateGraph={this.props.updateGraph} />
+                                {this.props.gId &&
+                                    <div className="form-group">
+                                            <a href={"/graph/" + this.props.gId + "/public/"}
+                                                   className="btn btn-secondary">Student View</a>
+                                        </div>
+                                    }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <CommonGraphSettings
@@ -585,7 +615,13 @@ export default class GraphEditor extends React.Component {
                                 gTitle={this.props.gTitle}
                                 gInstructorNotes={this.props.gInstructorNotes}
                                 gDescription={this.props.gDescription}
-                                updateGraph={this.props.updateGraph} />
+            updateGraph={this.props.updateGraph} />
+                                {this.props.gId &&
+                                    <div className="form-group">
+                                            <a href={"/graph/" + this.props.gId + "/public/"}
+                                                   className="btn btn-secondary">Student View</a>
+                                        </div>
+                                    }
                         </div>
                         <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
                             <CommonGraphSettings

--- a/src/GraphEditor.js
+++ b/src/GraphEditor.js
@@ -121,13 +121,6 @@ export default class GraphEditor extends React.Component {
                                     onClick={this.handleSaveGraph.bind(this)}>Save</button>
                             </div>
                             {this.props.gId &&
-                                    <div>
-                                        <button onClick={this.handleSaveGraph.bind(this)}
-                                            href={"/graph/" + this.props.gId + "/public/"}
-                                            className="btn btn-secondary">Save and View</button>
-                                    </div>
-                            }
-                            {this.props.gId &&
                                     <div className="ml-auto mr-3">
                                         <a role="button"
                                             className="btn btn-danger float-md-right"
@@ -233,13 +226,6 @@ export default class GraphEditor extends React.Component {
                                 onClick={this.handleSaveGraph.bind(this)}>Save</button>
                         </div>
                         {this.props.gId &&
-                                <div>
-                                    <button onClick={this.handleSaveGraph.bind(this)}
-                                        href={"/graph/" + this.props.gId + "/public/"}
-                                        className="btn btn-secondary">Save and View</button>
-                                </div>
-                        }
-                        {this.props.gId &&
                                 <div className="ml-auto mr-3">
                                     <a role="button"
                                         className="btn btn-danger float-md-right"
@@ -340,13 +326,6 @@ export default class GraphEditor extends React.Component {
                             onClick={this.handleSaveGraph.bind(this)}>Save</button>
                     </div>
                     {this.props.gId &&
-                            <div>
-                                <button onClick={this.handleSaveGraph.bind(this)}
-                                    href={"/graph/" + this.props.gId + "/public/"}
-                                    className="btn btn-secondary">Save and View</button>
-                            </div>
-                    }
-                    {this.props.gId &&
                             <div className="ml-auto mr-3">
                                 <a role="button"
                                     className="btn btn-danger float-md-right"
@@ -436,13 +415,6 @@ export default class GraphEditor extends React.Component {
                             className="btn btn-primary"
                             onClick={this.handleSaveGraph.bind(this)}>Save</button>
                     </div>
-                    {this.props.gId &&
-                            <div>
-                                <button onClick={this.handleSaveGraph.bind(this)}
-                                    href={"/graph/" + this.props.gId + "/public/"}
-                                    className="btn btn-secondary">Save and View</button>
-                            </div>
-                    }
                     {this.props.gId &&
                             <div className="ml-auto mr-3">
                                 <a role="button"
@@ -538,13 +510,6 @@ export default class GraphEditor extends React.Component {
                                 className="btn btn-primary"
                                 onClick={this.handleSaveGraph.bind(this)}>Save</button>
                         </div>
-                        {this.props.gId &&
-                                <div>
-                                    <button onClick={this.handleSaveGraph.bind(this)}
-                                        href={"/graph/" + this.props.gId + "/public/"}
-                                        className="btn btn-secondary">Save and View</button>
-                                </div>
-                        }
                         {this.props.gId &&
                                 <div className="ml-auto mr-3">
                                     <a role="button"
@@ -678,13 +643,6 @@ export default class GraphEditor extends React.Component {
                             className="btn btn-primary"
                             onClick={this.handleSaveGraph.bind(this)}>Save</button>
                     </div>
-                    {this.props.gId &&
-                            <div>
-                                <button onClick={this.handleSaveGraph.bind(this)}
-                                    href={"/graph/" + this.props.gId + "/public/"}
-                                    className="btn btn-secondary">Save and View</button>
-                            </div>
-                    }
                     {this.props.gId &&
                             <div className="ml-auto mr-3">
                                 <a role="button"

--- a/src/editors/CommonGraphEditor.js
+++ b/src/editors/CommonGraphEditor.js
@@ -11,16 +11,14 @@ export default class CommonGraphEditor extends React.Component {
         return (
             <div>
                 <div className="form-group">
-                    <label htmlFor="gTitle">
-                        Title
+                    <label htmlFor="gDescription">
+                        Description
                     </label>
-                    <input id="gTitle"
+                    <textarea id="gDescription"
                         onChange={handleFormUpdate.bind(this)}
-                        value={this.props.gTitle}
-                        className="form-control form-control-sm"
-                        type="text"
-                        maxLength="140"
-                    />
+                        value={this.props.gDescription}
+                        rows={4}
+                        className="form-control form-control-sm" />
                 </div>
                 <div className="form-group">
                     <label htmlFor="gInstructorNotes">
@@ -29,15 +27,6 @@ export default class CommonGraphEditor extends React.Component {
                     <textarea id="gInstructorNotes"
                         onChange={handleFormUpdate.bind(this)}
                         value={this.props.gInstructorNotes}
-                        className="form-control form-control-sm" />
-                </div>
-                <div className="form-group">
-                    <label htmlFor="gDescription">
-                        Description
-                    </label>
-                    <textarea id="gDescription"
-                        onChange={handleFormUpdate.bind(this)}
-                        value={this.props.gDescription}
                         className="form-control form-control-sm" />
                 </div>
             </div>

--- a/src/editors/CommonGraphSettings.js
+++ b/src/editors/CommonGraphSettings.js
@@ -10,7 +10,7 @@ export default class CommonGraphSettings extends React.Component {
     render() {
         return (
             <div>
-                <h2>Assignment Type</h2>
+                <h2>Assignment</h2>
                 <div className="form-group">
                     <label htmlFor="gAssignmentType">
                         Type

--- a/src/editors/CommonGraphSettings.js
+++ b/src/editors/CommonGraphSettings.js
@@ -13,7 +13,7 @@ export default class CommonGraphSettings extends React.Component {
                 <h2>Assignment Type</h2>
                 <div className="form-group">
                     <label htmlFor="gAssignmentType">
-                        Assignment type
+                        Type
                     </label>
                     <select id="gAssignmentType"
                         className="custom-select"


### PR DESCRIPTION
This commit:
- Give title to left col "Scenario"
- Order elements in left col:
  - Title
  - Graph
  - Desc: Now uses 4 lines of space by default
  - Notes
- In right col, rename "Assignment Type" to "Assignment"
- Rename label "Assignment Type" to "type"