### PR TITLE
Remove Unknown Graph Type message

### DIFF
--- a/src/GraphEditor.js
+++ b/src/GraphEditor.js
@@ -573,7 +573,7 @@ export default class GraphEditor extends React.Component {
                     </form>
                 </div>;
         } else {
-            return <div>Unknown graph type: {this.props.gType}</div>;
+            return null;
         }
     }
     handleSaveGraph() {

--- a/src/GraphViewer.js
+++ b/src/GraphViewer.js
@@ -611,7 +611,7 @@ export default class GraphViewer extends React.Component {
                 </form>
                 </div>;
         } else {
-            return <div>Unknown graph type: {this.props.gType}</div>;
+            return null;
         }
     }
     handleSubmit(event) {


### PR DESCRIPTION
This appears whenever the graph data is loading from the REST api, so it
doesn't really make sense to have as currently designed.