### PR TITLE
Make some small submission changes

### DIFF
--- a/src/buttons/SubmitButton.js
+++ b/src/buttons/SubmitButton.js
@@ -2,32 +2,35 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class SubmitButton extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            url: '#'
-        };
-    }
     render() {
-        if (!this.props.assessment || this.props.assessment.length === 0) {
-            return null;
-        }
+        const hasAssessment = !!this.props.assessment &&
+              this.props.assessment.length !== 0;
 
         return <React.Fragment>
             <hr style={{
                 display: (this.props.gNeedsSubmit && !this.props.submission) ? 'inherit' : 'none'
             }} />
 
+        {hasAssessment && (
             <button className="btn btn-primary btn-sm"
-        style={{
-            marginTop: '1em',
-            display: (!this.props.isInstructor && !this.props.submission) ? 'inherit' : 'none'
-        }}
-        type="submit">Submit</button>
+                    style={{
+                        marginTop: '1em',
+                        display: (!this.props.isInstructor && !this.props.submission) ? 'inherit' : 'none'
+                    }}
+                    type="submit">Submit</button>
+        )}
+
+        {!hasAssessment && (
+            <button className="btn btn-primary btn-sm"
+                    disabled="true"
+                    style={{
+                        marginTop: '1em',
+                        display: (!this.props.isInstructor && !this.props.submission) ? 'inherit' : 'none'
+                    }}
+                    type="submit">Submit</button>
+        )}
 
             </React.Fragment>;
-    }
-    onClick(evt) {
     }
 }
 

--- a/src/editors/CommonGraphSettings.js
+++ b/src/editors/CommonGraphSettings.js
@@ -32,7 +32,7 @@ export default class CommonGraphSettings extends React.Component {
                             type="checkbox"
                             onChange={handleFormUpdate.bind(this)}
                             checked={this.props.gNeedsSubmit} />
-                        Requires submission
+                        Requires assessment
                     </label>
                 </div>
                 <div className="form-check">


### PR DESCRIPTION
* Remove some unnecessary things from SubmitButton
* Rename "Requires submission" checkbox to "Requires assessment". This
toggles how the Submit button behaves in the student view. Non-assessed
(i.e. non-LTI) graphs can now be submitted, and have feedback displayed
immediately.