### PR TITLE
bugfix: enable submit button when "requires assessment" is true

### DIFF
--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -216,28 +216,43 @@ class Viewer extends Component {
         }
     }
 
-    componentDidMount() {
-        // Load graph and submission data
+    /**
+     * Get an assessment from Django and set it in this.state.
+     */
+    loadAssessment(gId) {
         const me = this;
 
-
-        this.getGraph().then(function() {
-            if (me.state.gNeedsSubmit) {
-                return me.getSubmission();
-            } else {
-                return null;
-            }
-        }).then(function(s) {
-            if (s) {
-                me.setState({submission: s});
-            }
-            return getAssessment(me.state.gId);
-        }).then(function(a) {
+        return getAssessment(gId).then(function(a) {
             if (a && a.assessmentrule_set) {
                 me.setState({assessment: a.assessmentrule_set});
             }
         }, function() {
-            // Assessment not found
+            // No assessment found
+        });
+    }
+
+    /**
+     * Get a submission from Django and set it in this.state.
+     */
+    loadSubmission(gId) {
+        const me = this;
+
+        return getSubmission(gId).then(function(s) {
+            me.setState({submission: s});
+        }, function() {
+            // No submission found
+        });
+    }
+
+    componentDidMount() {
+        // Load graph and submission data
+        const me = this;
+
+        this.getGraph().then(function() {
+            me.loadAssessment(me.state.gId);
+            if (me.state.gNeedsSubmit) {
+                me.loadSubmission(me.state.gId);
+            }
         });
 
         // Add graph feedback event handlers
@@ -288,10 +303,6 @@ class Viewer extends Component {
             }).then(function(json) {
                 importGraph(json, me);
             });
-    }
-
-    getSubmission() {
-        return getSubmission(this.state.gId);
     }
 
     /**

--- a/src/buttons/SubmitButton.js
+++ b/src/buttons/SubmitButton.js
@@ -6,19 +6,21 @@ export default class SubmitButton extends React.Component {
         const hasAssessment = !!this.props.assessment &&
               this.props.assessment.length !== 0;
 
+        if (!hasAssessment) {
+            return null;
+        }
+
         return <React.Fragment>
-            {hasAssessment && (
-                <div>
-                    <hr />
-                    <button className="btn btn-primary btn-sm"
-                            style={{
-                                marginTop: '1em',
-                                display: (!this.props.isInstructor && !this.props.submission) ?
-                                    'inherit' : 'none'
-                            }}
-                            type="submit">Submit</button>
-                </div>
-            )}
+            <div>
+            <hr />
+            <button className="btn btn-primary btn-sm"
+                style={{
+                    marginTop: '1em',
+                    display: (!this.props.isInstructor && !this.props.submission) ?
+                'inherit' : 'none'
+                }}
+                type="submit">Submit</button>
+            </div>
         </React.Fragment>;
     }
 }


### PR DESCRIPTION
The getSubmission call was interfering with the getAssessment call in
this code path. These two requests don't need to happen synchronously in
the promise chain so I've refactored them as necessary.