### PR TITLE
Revert "use internal text"

### DIFF
--- a/src/JXGBoard.js
+++ b/src/JXGBoard.js
@@ -87,9 +87,6 @@ export default class JXGBoard extends React.Component {
                 yAxisLabel = options.gYAxisLabel ? options.gYAxisLabel : 'y';
                 break;
         }
-        
-        // https://jsxgraph.uni-bayreuth.de/wp/2012/11/02/howto-export-jsxgraph-constructions/
-        JXG.Options.text.display = 'internal';
 
         let board = JXG.JSXGraph.initBoard(
             this.id, {


### PR DESCRIPTION
This reverts commit ceeb5a205a1b68df6f217e5985003f65c3a499f1.

This is causing some problems for Tom, and besides I think there's a
better way to fix this, using the renderer's [screenshot](https://jsxgraph.uni-bayreuth.de/docs/symbols/JXG.SVGRenderer.html#screenshot) functionality.