### PR TITLE
Use <figure> element for accessible semantics - ECON-364

### DIFF
--- a/src/JXGBoard.jsx
+++ b/src/JXGBoard.jsx
@@ -477,8 +477,9 @@ export default class JXGBoard extends React.Component {
     // for rendering the JSXGraph board div and any child elements
     render() {
         return (
-            <div id={this.id} className="jxgbox" style={this.style}>
-            </div>
+            <figure aria-label="The EconPractice graph."
+                    id={this.id} className="jxgbox" style={this.style}>
+            </figure>
         );
     }
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Figure_Role