### PR TITLE
Always use JSON format for api requests

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@
 const authedFetch = function(url, method = 'get', data = null) {
     const elt = document.getElementById('csrf-token');
     const token = elt ? elt.getAttribute('content') : '';
-    return fetch(url, {
+    return fetch(url + '?format=json', {
         method: method,
         headers: {
             'Accept': 'application/json, text/plain, */*',


### PR DESCRIPTION
For some reason, the drf API isn't respecting the
`Accept: application/json` setting here, and returning HTML.
This fixes that problem.