### PR TITLE
AUC: center label positions

### DIFF
--- a/src/Graph.js
+++ b/src/Graph.js
@@ -6,6 +6,7 @@
 
 import { defaultGraph } from './GraphMapping';
 import { forceFloat, getOffset, getXIntercept } from './utils';
+import { drawLabel } from './jsxgraphUtils';
 
 
 const applyDefaults = function(obj, defaults) {
@@ -402,15 +403,19 @@ class DemandSupplyGraphAUC extends DemandSupplyGraph {
             this.intersection.Y()
         ], invisiblePointOptions);
 
-        this.board.create('polygon', [
-            p1, p2, this.intersection
-        ], {
-            name: 'A',
-            withLabel: true,
+        const p3 = this.board.create('point', [
+            this.intersection.X(),
+            this.intersection.Y()
+        ], invisiblePointOptions);
+
+        const points = [p1, p2, p3];
+        this.board.create('polygon', points, {
+            withLabel: false,
             fillColor: 'purple',
             highlightFillColor: 'purple',
             ...triangleOptions
         });
+        drawLabel(this.board, points, 'A');
     }
     drawTriangleB() {
         const p1 = this.board.create('point', [
@@ -423,15 +428,19 @@ class DemandSupplyGraphAUC extends DemandSupplyGraph {
             this.l1.getRise()
         ], invisiblePointOptions);
 
-        this.board.create('polygon', [
-            this.intersection, p1, p2
-        ], {
-            name: 'B',
-            withLabel: true,
+        const p3 = this.board.create('point', [
+            this.intersection.X(),
+            this.intersection.Y()
+        ], invisiblePointOptions);
+
+        const points = [p3, p1, p2];
+        this.board.create('polygon', points, {
+            withLabel: false,
             fillColor: 'lime',
             highlightFillColor: 'lime',
             ...triangleOptions
         });
+        drawLabel(this.board, points, 'B');
     }
     drawTriangleC() {
         const p1 = this.board.create('point', [
@@ -442,15 +451,19 @@ class DemandSupplyGraphAUC extends DemandSupplyGraph {
         const xIntercept = getXIntercept(this.intersection, this.l1.getSlope());
         const p2 = this.board.create('point', [xIntercept, 0], invisiblePointOptions);
 
-        this.board.create('polygon', [
-            this.intersection, p1, p2
-        ], {
-            name: 'C',
-            withLabel: true,
+        const p3 = this.board.create('point', [
+            this.intersection.X(),
+            this.intersection.Y()
+        ], invisiblePointOptions);
+
+        const points = [p3, p1, p2];
+        this.board.create('polygon', points, {
+            withLabel: false,
             fillColor: 'red',
             highlightFillColor: 'red',
             ...triangleOptions
         });
+        drawLabel(this.board, points, 'C');
     }
 
     make() {
@@ -658,15 +671,19 @@ class NonLinearDemandSupplyGraphAUC extends NonLinearDemandSupplyGraph {
                 this.options.l1SubmissionOffset,
         ], invisiblePointOptions);
 
-        this.board.create('polygon', [
-            this.intersection, p1, p2
-        ], {
-            name: 'B',
-            withLabel: true,
+        const p3 = this.board.create('point', [
+            this.intersection.X(),
+            this.intersection.Y()
+        ], invisiblePointOptions);
+
+        const points = [p3, p2, p1];
+        this.board.create('polygon', points, {
+            withLabel: false,
             fillColor: 'lime',
             highlightFillColor: 'lime',
             ...triangleOptions
         });
+        drawLabel(this.board, points, 'B');
     }
     drawTriangleC() {
         const p1 = this.board.create('point', [
@@ -679,15 +696,19 @@ class NonLinearDemandSupplyGraphAUC extends NonLinearDemandSupplyGraph {
         const p2 = this.board.create(
             'point', [xIntercept, 0], invisiblePointOptions);
 
-        this.board.create('polygon', [
-            this.intersection, p1, p2
-        ], {
-            name: 'C',
-            withLabel: true,
+        const p3 = this.board.create('point', [
+            this.intersection.X(),
+            this.intersection.Y()
+        ], invisiblePointOptions);
+
+        const points = [p3, p2, p1];
+        this.board.create('polygon', points, {
+            withLabel: false,
             fillColor: 'red',
             highlightFillColor: 'red',
             ...triangleOptions
         });
+        drawLabel(this.board, points, 'C');
     }
 
     make() {

--- a/src/jsxgraphUtils.js
+++ b/src/jsxgraphUtils.js
@@ -1,0 +1,14 @@
+/**
+ * Given a board and an array of points,
+ * draw a label at the center of these points.
+ */
+const drawLabel = function(board, points, text) {
+    const group = board.create('group', points);
+    const center = group._update_centroid_center();
+
+    board.create('text', [center[0], center[1], text]);
+};
+
+export {
+    drawLabel
+};


### PR DESCRIPTION
Customize label positions for linear and non-linear Demand/Supply graphs.

![Screenshot from 2020-10-30 10-12-21](https://user-images.githubusercontent.com/59292/97715316-9c073000-1a98-11eb-84ed-b2f9f1a1b36e.png)
