### PR TITLE
Fix area label centering

### DIFF
--- a/src/jsxgraphUtils.js
+++ b/src/jsxgraphUtils.js
@@ -18,7 +18,8 @@ const shapeOptions = {
  * draw a label at the center of these points.
  */
 const drawLabel = function(board, points, text) {
-    const group = board.create('group', points);
+    const group = board.create('group', []);
+    group.addPoints(points);
     const center = group._update_centroid_center();
 
     board.create('text', [center[0], center[1], text], {


### PR DESCRIPTION
Something broke the centroid calculation here. It looks like it's fixed
by constructing the group of points differently, like this.