### PR TITLE
Load submission off graphId fetched from URL

### DIFF
--- a/src/Viewer.jsx
+++ b/src/Viewer.jsx
@@ -306,7 +306,7 @@ class Viewer extends Component {
         this.getGraph().then(function() {
             me.loadAssessment(me.graphId);
             if (me.state.gNeedsSubmit) {
-                me.loadSubmission(me.state.gId);
+                me.loadSubmission(me.graphId);
             }
         });
 


### PR DESCRIPTION
Don't rely on this.state's graphId - this requires the graph data to be imported, and it looks like there is a quirk with synchronizing the promise in getGraph. Just use this.graphId here since this will be immediately present (see where this is set in the constructor).

This fixes a problem where the graphId could potentially be null.